### PR TITLE
WIP: Paragraph as node description

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "@gera2ld/plaid-rollup": "~2.3.0",
     "del-cli": "^3.0.1",
     "husky": "^5.1.3",
-    "lerna": "^4.0.0"
+    "lerna": "^4.0.0",
+    "yarn": "^1.22.10"
   },
   "scripts": {
     "prepare": "husky install",

--- a/packages/markmap-common/src/types/common.ts
+++ b/packages/markmap-common/src/types/common.ts
@@ -22,6 +22,10 @@ export interface INode extends IHierarchy<INode> {
    * value
    */
   v: string;
+  /**
+   * description
+   */
+  description?: string;
 }
 
 export type JSScriptItem = {

--- a/packages/markmap-lib/src/transform.ts
+++ b/packages/markmap-lib/src/transform.ts
@@ -26,10 +26,10 @@ function cleanNode(node: INode, depth = 0): void {
         if (index === 0) {
           node.description = item.v;
         } else {
-          node.c[index-1].description = item.v;
+          node.c[index - 1].description = item.v;
         }
       }
-    })
+    });
 
     // paragraph aren't needed further
     node.c = node.c.filter((item) => item.t !== 'paragraph');

--- a/packages/markmap-view/src/index.ts
+++ b/packages/markmap-view/src/index.ts
@@ -136,7 +136,8 @@ export class Markmap {
 .${id}-fo em { font-style: italic; }
 .${id}-fo strong { font-weight: bolder; }
 .${id}-fo pre { margin: 0; padding: .2em .4em; }
-.${id}-fo > div > .title { padding: .2em .4em; }
+.${id}-fo > div > .title { padding: .2em; }
+.${id}-fo > div > .description { padding: 0 .2em; }
 ${extraStyle}
 `;
     return styleText;
@@ -231,6 +232,7 @@ ${this.getStyleContent()}
           Math.ceil(descriptionRect?.width || 0),
           Math.max(Math.ceil(descriptionRect?.height || 0), nodeMinHeight),
         ],
+        hideDescription: item.description ? false : true,
         // unique ID
         i,
         el,


### PR DESCRIPTION
Hi! I've been working on #28 the last few days. If a "thing" turns into a node, then the paragraph *after* it is added as a description.

This is how it looks for now: ![image](https://user-images.githubusercontent.com/25766329/122606241-e44f7e80-d078-11eb-8abf-7656dd7f9272.png)

Some things to note:
- I'm *not* a designer. I've simply tried to replicate the style mentioned in #28 (grey arrow to toggle description). If anyone has a nicer design in mind, please say so!

- Bug: some images are cut off if they're used as description. I haven't found the reason for this yet ![image](https://user-images.githubusercontent.com/25766329/122606948-14e3e800-d07a-11eb-90d9-7106bade1f1e.png)

- Todo: when pressing the arrow to hide the description, the description disappears without animation. I do not know how to add a transition to it. Could you help with this @gera2ld? The HTMLParagraphElement with the `.description` class should have a transition when being removed.

P.S.: single character node properties make the code hard to read :(