### PR TITLE
README.md: adds missing packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,11 @@ This project is heavily inspired by [dundalek's markmap](https://github.com/dund
 
 ## Packages
 
+- [markmap-common](https://github.com/markmap/markmap/tree/master/packages/markmap-common)
+  ![NPM](https://img.shields.io/npm/v/markmap-common.svg)
+
+Common types and utility functions used by markmap packages.
+
 - [markmap-lib](https://github.com/gera2ld/markmap/tree/master/packages/markmap-lib)
   ![NPM](https://img.shields.io/npm/v/markmap-lib.svg)
 
@@ -21,6 +26,16 @@ This project is heavily inspired by [dundalek's markmap](https://github.com/dund
   ![NPM](https://img.shields.io/npm/v/markmap-view.svg)
 
   Render markmap in browser.
+
+- [markmap-autoloader](https://github.com/markmap/markmap/tree/master/packages/markmap-autoloader)
+  ![NPM](https://img.shields.io/npm/v/markmap-autoloader.svg)
+
+  Load markmaps automatically in HTML.
+
+- [markmap-toolbar](https://github.com/markmap/markmap/tree/master/packages/markmap-toolbar)
+  ![NPM](https://img.shields.io/npm/v/markmap-toolbar.svg)
+
+  Extensible toolbar for markmap.
 
 - [markmap-cli](https://github.com/gera2ld/markmap/tree/master/packages/markmap-cli)
   ![NPM](https://img.shields.io/npm/v/markmap-cli.svg)

--- a/packages/markmap-autoloader/README.md
+++ b/packages/markmap-autoloader/README.md
@@ -28,10 +28,16 @@ HTML:
 
 Note that `<script type="text/template">` is optional, for the content inside to be invisible before the markmap is rendered.
 
-Autoload all elements matching `.markmap`:
+Autoload all elements matching `.markmap`, using latest autoloader version:
 
 ```html
-<script src="https://cdn.jsdelivr.net/npm/markmap-autoloader"></script>
+<script src="https://cdn.jsdelivr.net/npm/markmap-autoloader@latest"></script>
+```
+
+To use specific version (here: `0.14.3`) of `mark-autoloader`:
+
+```html
+<script src="https://cdn.jsdelivr.net/npm/markmap-autoloader@0.14.3"></script>
 ```
 
 Load manually:


### PR DESCRIPTION
This PR adds packages to `README.md`. It also extends `README.md` of package `markmap-autoloader` with instructions on how to use a specific version of `markmap-autoloader`.