### PR TITLE
Disable mousedown events for circles

### DIFF
--- a/packages/markmap-view/src/view.tsx
+++ b/packages/markmap-view/src/view.tsx
@@ -419,7 +419,9 @@ export class Markmap {
             .attr('cx', (d) => d.ySizeInner)
             .attr('cy', (d) => d.xSize)
             .attr('r', 0)
-            .on('click', (e, d) => this.handleClick(e, d));
+            .on('click', (e, d) => this.handleClick(e, d))
+            .on('mousedown', stopPropagation)
+            .on('dblclick', stopPropagation);
         },
         (update) => update,
         (exit) => exit.remove()


### PR DESCRIPTION
mousedown e is too sensitive on circle elements, ruins UX when they don't click fast enough (basically they pan instead of expanding a branch if the mouse moves a nanometer while clicking)

close #184 