### PR TITLE
added test.* to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ packages/*/dist
 .nyc_output/
 packages/*/coverage
 packages/*/types
+
+# test files created by users
+test.*


### PR DESCRIPTION
added `test.*` to `.gitignore` file 

developers might want to create testing files this makes git ignore them